### PR TITLE
Adds "requires" field to the game description

### DIFF
--- a/homunculus.py
+++ b/homunculus.py
@@ -264,7 +264,8 @@ world = {
           "label": "To the Admin rooms",
           "newPassage": "Administration",
           "pid": "18",
-          "selection": "7"
+          "selection": "7",
+          "requires":"12"
         }
       ],
       "cleanText": "You walk through the door from the airlock into a large, octagonal room. There are 8 doors, one for each side of the room- counting the one you just walked in from. They have labels above the doors for each branch off of the hallway."

--- a/main.py
+++ b/main.py
@@ -10,27 +10,30 @@ def find_current_location(world, pid):
 
 # ----------------------------------------------------------------
 
-def render(world, current_location):
+def render(world, current_location, visited):
   if "name" in current_location and "cleanText" in current_location and "links" in current_location:
     print(current_location["cleanText"])
     print()
     for link in current_location["links"]:
-      print("({}) {}".format(link["selection"], link["label"]))
+      if "requires" not in link or link["requires"] in visited:
+        print("({}) {}".format(link["selection"], link["label"]))
     print("\n")
         
 def get_input():
   response = input("What do you want to do? (type quit to quit)? ")
   return response.upper().strip()
 
-def update(world, current_location, current_pid, response):
+def update(world, current_location, current_pid, response, visited):
   if response == "":
     return current_pid
   if "links" in current_location:
     for link in current_location["links"]:
       if response == link["selection"]:
-        return link["pid"]
+        if "requires" not in link or link["requires"] in visited:
+          return link["pid"]
       if response == link["label"].upper().strip():
-        return link["pid"]
+        if "requires" not in link or link["requires"] in visited:
+          return link["pid"]
   print("I don't know what you are trying to do.")
   return current_pid
 
@@ -47,6 +50,7 @@ pid = 0
 if "startnode" in hmc:
   pid = hmc["startnode"]
 current_location = {}
+visited = []
 response = ""
 gl_count = 0
 
@@ -56,11 +60,14 @@ while True:
     break
   if gl_count >= 10:
     break
-  pid = update(hmc, current_location, pid, response)
+  pid = update(hmc, current_location, pid, response, visited)
+  if pid != "" and pid not in visited:
+    visited.append(pid)
   current_location = find_current_location(hmc, pid)
-  render(hmc, current_location)
+  render(hmc, current_location, visited)
   gl_count = count_moves(gl_count)
   print(gl_count)
+  #print(visited)
   response = get_input()
 print("Thanks for playing!")
 print("Your total action count was: {}".format(str(gl_count)))


### PR DESCRIPTION
I am now tracking visited PIDs in the "visited" list (and passing it to render() and update()). If you add a "requires" key to a link, it will only appear if that PID has been visited. The passage to the Admin Rooms (line 268) is an example.